### PR TITLE
Fix prefix

### DIFF
--- a/src/EnvireOdeCollisionPlugins.cpp
+++ b/src/EnvireOdeCollisionPlugins.cpp
@@ -240,7 +240,7 @@ namespace mars
                     }
                 }
                 //fprintf(stderr, "%s\n", config.toYamlString().c_str());
-                node.fromConfigMap(&config, "");
+                node.fromConfigMap(&config, config["filePrefix"].toString());
                 ControlCenter::loadCenter->loadMesh->getPhysicsFromMesh(&node);
                 ((ode_collision::Mesh*)collision)->setMeshData(node.mesh);
                 config["extend"]["x"] = node.ext.x();
@@ -252,7 +252,7 @@ namespace mars
             if(config["type"] == "heightfield")
             {
                 NodeData node;
-                node.fromConfigMap(&config, "");
+                node.fromConfigMap(&config, config["filePrefix"].toString());
 
                 // check physics type:
                 if(node.terrain)
@@ -260,10 +260,6 @@ namespace mars
                     if(!node.terrain->pixelData)
                     {
                         LOG_INFO("Load heightmap pixelData...");
-                        //nodeData.terrain = new(terrainStruct);
-                        // TODO: add proper path handling
-                        node.terrain->srcname = config["filePrefix"].toString() + "/" + node.terrain->srcname;
-                        LOG_INFO(node.terrain->srcname.c_str());
                         ControlCenter::loadCenter->loadHeightmap->readPixelData(node.terrain);
                         if(!node.terrain->pixelData)
                         {
@@ -271,8 +267,7 @@ namespace mars
                         }
                     }
 
-
-                    ((ode_collision::Heightfield*)collision)->setTerrainStrcut(node.terrain);
+                    ((ode_collision::Heightfield*)collision)->setTerrainStruct(node.terrain);
                     if(!collision->createGeom())
                     {
                         LOG_ERROR("Error creating Heightfield geom!");

--- a/src/EnvireOdeCollisionPlugins.cpp
+++ b/src/EnvireOdeCollisionPlugins.cpp
@@ -267,7 +267,7 @@ namespace mars
                         }
                     }
 
-                    ((ode_collision::Heightfield*)collision)->setTerrainStruct(node.terrain);
+                    ((ode_collision::Heightfield*)collision)->setTerrainStrcut(node.terrain);
                     if(!collision->createGeom())
                     {
                         LOG_ERROR("Error creating Heightfield geom!");

--- a/src/EnvireOdeCollisionPlugins.cpp
+++ b/src/EnvireOdeCollisionPlugins.cpp
@@ -242,7 +242,7 @@ namespace mars
                 //fprintf(stderr, "%s\n", config.toYamlString().c_str());
                 node.fromConfigMap(&config, config["filePrefix"].toString());
                 ControlCenter::loadCenter->loadMesh->getPhysicsFromMesh(&node);
-                ((ode_collision::Mesh*)collision)->setMeshData(node.mesh);
+                dynamic_cast<ode_collision::Mesh*>(collision)->setMeshData(node.mesh);
                 config["extend"]["x"] = node.ext.x();
                 config["extend"]["y"] = node.ext.y();
                 config["extend"]["z"] = node.ext.z();
@@ -267,7 +267,7 @@ namespace mars
                         }
                     }
 
-                    ((ode_collision::Heightfield*)collision)->setTerrainStrcut(node.terrain);
+                    dynamic_cast<ode_collision::Heightfield*>(collision)->setTerrainStrcut(node.terrain);
                     if(!collision->createGeom())
                     {
                         LOG_ERROR("Error creating Heightfield geom!");


### PR DESCRIPTION
To be independent from the working directory when loading a scene, the path to the folder containing the scene needs to be used as prefix for meshes to be loaded.